### PR TITLE
plugins tetris, matrix and time_matrix changed to wci from wcb 

### DIFF
--- a/wordclock_plugins/matrix/plugin.py
+++ b/wordclock_plugins/matrix/plugin.py
@@ -1,7 +1,6 @@
 # Authored by Markus E.
 
 import os
-#import wordclock_tools.buttons as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 

--- a/wordclock_plugins/matrix/plugin.py
+++ b/wordclock_plugins/matrix/plugin.py
@@ -1,7 +1,7 @@
 # Authored by Markus E.
 
 import os
-import wordclock_tools.buttons as wcb
+#import wordclock_tools.buttons as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 
@@ -56,12 +56,12 @@ class plugin:
                     rain[x] = y + 1
             wcd.show()
             # input handling
-            event = wci.waitSecondsForEvent([wcb.button_return, wcb.button_left, wcb.button_right], 0.1)
-            if event == wcb.button_return:
+            event = wci.waitSecondsForEvent([wci.button_return, wci.button_left, wci.button_right], 0.1)
+            if event == wci.button_return:
                 return
-            elif event == wcb.button_left:
+            elif event == wci.button_left:
                 self.threshold = min(0.95, self.threshold + 0.05)
-            elif event == wcb.button_right:
+            elif event == wci.button_right:
                 self.threshold = max(0.7, self.threshold - 0.05)
 
 

--- a/wordclock_plugins/tetris/plugin.py
+++ b/wordclock_plugins/tetris/plugin.py
@@ -1,7 +1,6 @@
 # Authored by Markus E.
 
 import os
-#import wordclock_tools.buttons as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 import time

--- a/wordclock_plugins/tetris/plugin.py
+++ b/wordclock_plugins/tetris/plugin.py
@@ -1,7 +1,7 @@
 # Authored by Markus E.
 
 import os
-import wordclock_tools.buttons as wcb
+#import wordclock_tools.buttons as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 import time
@@ -92,7 +92,7 @@ class plugin:
                 self.carve(brick, x, y)
                 self.draw(wcd)
 
-                event = wci.waitSecondsForEvent([wcb.button_return,wcb.button_left,wcb.button_right], 0.01, 1000)
+                event = wci.waitSecondsForEvent([wci.button_return,wci.button_left,wci.button_right], 0.01, 1000)
                 # check the time
                 d = time.time() - t
                 timeout = d > max(0.2, (0.5 - 0.02 * lines)) # make game harder over time
@@ -114,7 +114,7 @@ class plugin:
 
                 lastevent = event
 
-                if event == wcb.button_return:
+                if event == wci.button_return:
                     brickr = brick.rotate_cw()
                     # simple wall bounce
                     if not self.collision(brickr, x, y):
@@ -128,12 +128,12 @@ class plugin:
                     # adjust x and y
                     x = min(max(-brick.padLeft, x), W - brick.innerWidth - brick.padLeft)
                     y = max(-brick.padTop - brick.innerHeight + 1, y)
-                elif event == wcb.button_left:
+                elif event == wci.button_left:
                     # move brick to the left
                     nx = max(-brick.padLeft, x - 1)
                     if not self.collision(brick, nx, y):
                         x = nx
-                elif event == wcb.button_right:
+                elif event == wci.button_right:
                     # move brick to the right
                     nx = min(x + 1, W - brick.innerWidth - brick.padLeft)
                     if not self.collision(brick, nx, y):

--- a/wordclock_plugins/time_default/plugin.py
+++ b/wordclock_plugins/time_default/plugin.py
@@ -24,6 +24,8 @@ class plugin:
         language = config.get('plugin_' + self.name, 'language')
         if language == 'german':
             self.taw = time_german.time_german()
+        elif language == 'swabian':
+            self.taw = time_swabian.time_swabian()
         else:
             print('Could not detect language: ' + language + '.')
             print('Choosing default: german')

--- a/wordclock_plugins/time_default/time_swabian.py
+++ b/wordclock_plugins/time_default/time_swabian.py
@@ -35,7 +35,7 @@ class time_swabian():
         range(49,54)]
     self.full_hour= range(107,110)
 
-def get_time(self, time, withPrefix=True):
+ def get_time(self, time, withPrefix=True):
     hour=time.hour%12+(1 if time.minute/5 > 2 else 0)
     minute=time.minute/5
     # Assemble indices

--- a/wordclock_plugins/time_matrix/plugin.py
+++ b/wordclock_plugins/time_matrix/plugin.py
@@ -3,7 +3,7 @@
 import datetime
 import os
 import wordclock_plugins.time_default.time_german as time_german
-import wordclock_tools.buttons as wcb
+#import wordclock_tools.buttons as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 from ConfigParser import NoSectionError
@@ -84,12 +84,12 @@ class plugin:
 
             wcd.show()
 
-            event = wci.waitSecondsForEvent([wcb.button_return, wcb.button_left, wcb.button_right], 0.1)
-            if event == wcb.button_return:
+            event = wci.waitSecondsForEvent([wci.button_return, wci.button_left, wci.button_right], 0.1)
+            if event == wci.button_return:
                 return
-            elif event == wcb.button_left:
+            elif event == wci.button_left:
                 self.threshold = min(0.95, self.threshold + 0.05)
-            elif event == wcb.button_right:
+            elif event == wci.button_right:
                 self.threshold = max(0.7, self.threshold - 0.05)
 
 

--- a/wordclock_plugins/time_matrix/plugin.py
+++ b/wordclock_plugins/time_matrix/plugin.py
@@ -3,7 +3,6 @@
 import datetime
 import os
 import wordclock_plugins.time_default.time_german as time_german
-#import wordclock_tools.buttons as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 from ConfigParser import NoSectionError


### PR DESCRIPTION
these newer plugins still used wcb - but buttons.py does not exist anymore.
--> changed to use wci like in the other plugins.

and small change to time_default to be able to select swabian.

now running on my wordclock as expected.