### PR TITLE
Disable swipe in webinterface

### DIFF
--- a/wordclock_interfaces/templates/app.html
+++ b/wordclock_interfaces/templates/app.html
@@ -63,6 +63,7 @@
                                         </v-card-text>
                                     </v-card>
                                 </v-dialog>
+                                <v-tabs-items touchless>
                                 <v-tab-item>
                                     <v-card height=562>
                                         <v-card-text>
@@ -170,6 +171,7 @@
                                         </v-card-actions>
                                     </v-card>
                                 </v-tab-item>
+                                </v-tabs-items>
                             </v-tabs>
                       </v-flex>
                     </v-layout>


### PR DESCRIPTION
This pull request disables swiping in the webinterface to allow better control of the slider and colour ring when using a touchscreen.