### PR TITLE
Fix for empty Webinterface

### DIFF
--- a/wordclock_interfaces/templates/app.html
+++ b/wordclock_interfaces/templates/app.html
@@ -6,10 +6,10 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel='stylesheet prefetch' href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons'>
-    <link rel='stylesheet prefetch' href='https://unpkg.com/vuetify/dist/vuetify.min.css'>
+    <link rel='stylesheet prefetch' href='https://unpkg.com/vuetify@1.5.16/dist/vuetify.min.css'>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
     <script src='https://unpkg.com/vue/dist/vue.min.js'></script>
-    <script src='https://unpkg.com/vuetify/dist/vuetify.js'></script>
+    <script src='https://unpkg.com/vuetify@1.5.16/dist/vuetify.js'></script>
     <script src='https://unpkg.com/babel-polyfill/dist/polyfill.min.js'></script>
     <!--script src="https://unpkg.com/@radial-color-picker/vue-color-picker/dist/vue-color-picker.min.js"></script-->
 	<script src="static/js/vue-color-picker.js"></script>


### PR DESCRIPTION
This commit fixes issue #126.
The issue was caused by a major update of Vuetify from 1.5 to 2.0. This caused (apperantly) backwards compatability issue. I fixed the used version of Vuetify to the latest stable 1.5 release.