### PR TITLE
set LED pin in config,  set animation in config, sleep timer fix, ping function

### DIFF
--- a/wordclock.py
+++ b/wordclock.py
@@ -13,7 +13,7 @@ import wordclock_interfaces.web_interface as wciweb
 
 
 # Get wordclock configuration from config-file
-def loadConfig (basePath):
+def loadConfig(basePath):
     pathToConfigFile = basePath + '/wordclock_config/wordclock_config.cfg'
     if not os.path.exists(pathToConfigFile):
         pathToConfigFileExample = basePath + '/wordclock_config/wordclock_config.example.cfg'
@@ -32,7 +32,6 @@ def loadConfig (basePath):
     config.set('wordclock', 'base_path', basePath)
 
     return config
-
 
 
 class wordclock:
@@ -84,7 +83,8 @@ class wordclock:
                     logging.info('Skipping plugin ' + plugin + ' since it is set to activate=false in the config-file.')
                     continue
             except:
-                logging.debug('No activate-flag set for plugin ' + plugin + ' within the config-file. Will be imported.')
+                logging.debug(
+                    'No activate-flag set for plugin ' + plugin + ' within the config-file. Will be imported.')
 
             try:
                 # Perform a minimal (!) validity check
@@ -123,11 +123,12 @@ class wordclock:
         """
 
         try:
-	        logging.info('Running plugin ' + self.plugins[self.plugin_index].name + '.')
-	        self.plugins[self.plugin_index].run(self.wcd, self.wci)
+            logging.info('Running plugin ' + self.plugins[self.plugin_index].name + '.')
+            self.plugins[self.plugin_index].run(self.wcd, self.wci)
         except:
             logging.error('Error in plugin ' + self.plugins[self.plugin_index].name + '.')
-            logging.error('PLEASE PROVIDE THE CURRENT SOFTWARE VERSION (GIT HASH), WHEN REPORTING THIS ERROR: ' + self.currentGitHash)
+            logging.error(
+                'PLEASE PROVIDE THE CURRENT SOFTWARE VERSION (GIT HASH), WHEN REPORTING THIS ERROR: ' + self.currentGitHash)
             self.wcd.setImage(os.path.join(self.pathToGeneralIcons, 'error.png'))
             raise
 
@@ -135,7 +136,7 @@ class wordclock:
         self.wcd.resetDisplay()
 
     def runNext(self, plugin_index=None):
-        if(plugin_index == self.plugin_index):
+        if (plugin_index == self.plugin_index):
             return
         self.plugin_index = plugin_index if plugin_index is not None else self.default_plugin
         self.wci.setEvent(self.wci.EVENT_NEXT_PLUGIN_REQUESTED)
@@ -177,8 +178,8 @@ class wordclock:
                             self.plugin_index = 0
                         time.sleep(self.wci.lock_time)
 
-if __name__ == '__main__':
 
+if __name__ == '__main__':
     # Setup logging
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s: %(message)s')
 

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -23,6 +23,8 @@ language = german
 
 # Choose wiring layout here. Options are: bernds_wiring, christians_wiring, ... (possibly you need your own wiring layout)
 wiring_layout = bernds_wiring
+# GPIO pin connected to the pixels (must support PWM!)
+led_pin = 12
 
 # Fonts available at /usr/share/fonts/... (e.g. some types listed in truetype/freefont)
 # FreeMono FreeMonoBoldOblique FreeSans FreeSansBoldOblique FreeSerif FreeSerifBoldItalic

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -22,8 +22,8 @@ developer_mode = False
 language = german
 
 # Choose wiring layout here. Options are: bernds_wiring, christians_wiring, ... (possibly you need your own wiring layout)
-wiring_layout = bernds_wiring
-# GPIO pin connected to the pixels (must support PWM!)
+wiring_layout = davids_wiring
+# GPIO pin connected to the pixels (must support PWM!).
 led_pin = 12
 
 # Fonts available at /usr/share/fonts/... (e.g. some types listed in truetype/freefont)
@@ -32,7 +32,10 @@ led_pin = 12
 default_font = wcfont
 
 # Set the brightness of the display (between 1 and 255)
-brightness = 200
+brightness = 255
+use_brightness_sensor = True
+# GPIO pin connected to photo resistor
+pin_brightness_sensor = 18
 
 [wordclock_interface]
 # Defines type of interface (gpio_low: pin is set to low on event, gpio_high: pin is set to high on event, no_gpio: no pins are read at all (= disabled hardware buttons))

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -108,6 +108,14 @@ sleep_end_minute = 0
 # [0-255]
 sleep_brightness = 0
 
+[ping_checker]
+# ping device IPs to check if somebody home, if not turn off brightness
+activate = True
+# list of device IPs that should be pinged
+ip_addresses = ["192.168.0.241", "192.168.0.242"]
+# duration in minutes the clock will be lit after last successful ping
+shut_off_duration = 2
+
 [plugin_time_matrix]
 activate = True
 

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -24,7 +24,7 @@ language = german
 # Choose wiring layout here. Options are: bernds_wiring, christians_wiring, ... (possibly you need your own wiring layout)
 wiring_layout = bernds_wiring
 # GPIO pin connected to the pixels (must support PWM!)
-led_pin = 12
+led_pin = 18
 
 # Fonts available at /usr/share/fonts/... (e.g. some types listed in truetype/freefont)
 # FreeMono FreeMonoBoldOblique FreeSans FreeSansBoldOblique FreeSerif FreeSerifBoldItalic

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -96,12 +96,17 @@ typewriter = false
 typewriter_speed = 10
 # show time without prefix IT IS/ES IST/etc.
 purist = False
-# define sleep times when the display brightness is turned down [define any 
-sleep_begin_hour = 0	# [0-23]
-sleep_begin_minute = 0	# [0-59]
-sleep_end_hour = 0	# [0-23]
-sleep_end_minute = 0	# [0-59]
-sleep_brightness = 10	# [0-255]
+# define sleep times when the display brightness is turned down [define any
+# [0-23]
+sleep_begin_hour = 0
+# [0-59]
+sleep_begin_minute = 0
+# [0-23]
+sleep_end_hour = 0
+# [0-59]
+sleep_end_minute = 0
+# [0-255]
+sleep_brightness = 0
 
 [plugin_time_matrix]
 activate = True

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -91,9 +91,9 @@ activate = True
 
 [plugin_time_default]
 activate = True
-# animate new time with typewriter animation
-typewriter = false
-typewriter_speed = 10
+# animate new time. Options: no_animation, typewriter, fadeOutIn
+animation = no_animation
+animation_speed = 10
 # show time without prefix IT IS/ES IST/etc.
 purist = False
 # define sleep times when the display brightness is turned down [define any

--- a/wordclock_plugins/time_default/plugin.py
+++ b/wordclock_plugins/time_default/plugin.py
@@ -126,22 +126,21 @@ class plugin:
             # Get current time
             now = datetime.datetime.now()
             # Check if this is the predefined sleep time (muted brightness) as defined in wordclock_config.cfg
-            nowtime = datetime.time(now.hour,now.minute,0)
-            if not (self.sleep_begin == self.sleep_end):
-                if ((self.sleep_begin <= nowtime) and ((nowtime <= self.sleep_end) or (nowtime <= datetime.time(23,59,59))) or (datetime.time(0,0,0) <= nowtime <= self.sleep_end)):  # skip if color/brightness change has been done during the current sleep cycle
-                    if not self.skip_sleep: 
-                        self.brightness_mode_pos = self.sleep_brightness
-                        self.sleep_switch = True  # brightness has been changed
-                    self.is_sleep = True 
+            nowtime = datetime.time(now.hour, now.minute, 0)
+            if not self.sleep_begin == self.sleep_end:
+                if self.sleep_begin <= nowtime <= self.sleep_end:
+                    # skip if color/brightness change has been done during the current sleep cycle
+                    if self.skip_sleep:
+                        wcd.setBrightness(self.brightness_mode_pos)
+                    else:
+                        wcd.setBrightness(self.sleep_brightness)
+                    self.is_sleep = True
                 else:
-                    self.brightness_mode_pos = self.wake_brightness
-                    self.sleep_switch = True  # brightness has been changed
-                    self.skip_sleep = False   # reset skip flag, returning to normal sleep/wake cycle
+                    wcd.setBrightness(self.brightness_mode_pos)
+                    self.skip_sleep = False  # reset skip flag, returning to normal sleep/wake cycle
                     self.is_sleep = False
-            # has brightness changed? then implement change in wcd
-            if self.sleep_switch:
+            else:
                 wcd.setBrightness(self.brightness_mode_pos)
-                self.sleep_switch = False  # reset switch
             # Check, if a minute has passed (to render the new time)
             if prev_min < now.minute:
                 # Set background color

--- a/wordclock_plugins/time_default/plugin.py
+++ b/wordclock_plugins/time_default/plugin.py
@@ -106,8 +106,8 @@ class plugin:
         self.is_sleep = False
 
         self.bg_color = wcc.BLACK  # default background color
-        self.word_color = wcc.WWHITE  # default word color
-        self.minute_color = wcc.WWHITE  # default minute color
+        self.word_color = wcc.WHITE  # default word color
+        self.minute_color = wcc.WHITE  # default minute color
 
         # Other color modes...
         self.color_modes = \
@@ -154,18 +154,18 @@ class plugin:
                     if self.sleep_begin <= nowtime <= self.sleep_end:
                         # skip if color/brightness change has been done during the current sleep cycle
                         if self.skip_sleep:
-                            wcd.setBrightness(self.brightness_mode_pos)
+                            wcd.setBrightness()
                         else:
                             wcd.setBrightness(self.sleep_brightness)
                         self.is_sleep = True
                     else:
-                        wcd.setBrightness(self.brightness_mode_pos)
+                        wcd.setBrightness()
                         self.skip_sleep = False  # reset skip flag, returning to normal sleep/wake cycle
                         self.is_sleep = False
                 else:
-                    wcd.setBrightness(self.brightness_mode_pos)
+                    wcd.setBrightness()
             else:
-                wcd.setBrightness(0)
+                wcd.setBrightness()
             # Check, if a minute has passed (to render the new time)
             if prev_min < now.minute:
                 if self.ping_activated:

--- a/wordclock_plugins/time_default/plugin.py
+++ b/wordclock_plugins/time_default/plugin.py
@@ -35,19 +35,20 @@ class plugin:
 
         # typewriter effect
         try:
-            self.typewriter = config.getboolean('plugin_' + self.name, 'typewriter')
+            self.animation = config.get('plugin_' + self.name, 'animation')
         except:
-            logging.warning('No typewriter-flag set for default plugin within the config-file. Typewriter animation will be used.')
-            self.typewriter = True
+            logging.warning('No animation-flag set for default plugin within the config-file. No animation will be used.')
 
-        self.animation = "typewriter" if self.typewriter else "fadeOutIn"
+        if not any([self.animation == animation_type for animation_type in ['typewriter', 'fadeOutIn']]):
+            self.animation = None
+        # self.animation = "typewriter" if self.animation else "fadeOutIn"
 
         try:
-            self.typewriter_speed = config.getint('plugin_' + self.name, 'typewriter_speed')
+            self.animation_speed = config.getint('plugin_' + self.name, 'animation_speed')
         except:
-            self.typewriter_speed = 5
-            logging.warning('No typewriter_speed set for default plugin within the config-file. Defaulting to ' + str(
-                self.typewriter_speed) + '.')
+            self.animation_speed = 5
+            logging.warning('No animation_spped set for default plugin within the config-file. Defaulting to ' + str(
+                self.animation_speed) + '.')
 
         try:
             self.purist = config.getboolean('plugin_time_default', 'purist')


### PR DESCRIPTION
Hi,

maybe the things I've done or parts of it are useful. The contribution consists of four commits:
- I moved the LED pin declaration into the configuration file so that others can set the wiring more flexible without code edits. (I figured since temperature sensor pin is declared in the config file, it may also be the right place for the LED pin.) Also contributed my own wiring.
- I discoverd that the sleep timer didn't work because of two reasons:
 -1. In the config-file the time settings had inline comments which messed with the readout of the parameters. I changed the descriptive comments to be one line above the time-parameters.
 -2. The actual decision making to activate sleep mode wasn't working. I changed it and it works for me (also skipping the sleep cycle works)
- I implemented a ping function. every minute it pings for certain devices in the local network. if a certain time (`shut_off_duration`) has passed without successful ping, the brightness is set to 0 to save energy. The activation of the ping_function, the IP's of the devices to be pinged and the `shut_off_duration` are set in the configuration file.
- Lastly I made the animation feature optinal in config file. It can be choosen between: no_animation, typewriter, fadeOutIn.