### PR TITLE
Add french, default colors in config, change order of minutes, example config missing

### DIFF
--- a/docs/doc_general_considerations.rst
+++ b/docs/doc_general_considerations.rst
@@ -19,10 +19,10 @@ If you want to build a wordclock
           * english (Thanks to Alexandre)
           * dutch (Thanks to svenjacobi, resolution is 10x9. Therefore, not all plugins are supported!)
           * swiss
+          * french
 
       * Stancil layout only (requiring some python-implementations: See wordclock_plugins/time_default):
 
-          * french
           * italian
           * spanish
           * turkish

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -9,10 +9,6 @@ show_startup_message = True
 # Can be a string like "Hello world" or the keyword "ShowIP" to display the wordclocks IP-address (to access the web interface)
 startup_message = ShowIP
 
-# BLACK, WHITE, WWHITE, RED, YELLOW, LIME, GREEN, BLUE
-default-fg-color = WWHITE
-default-bg-color = BLACK
-
 # Set to True to run the software with GTK on a linux system
 # * Does not require any wordclock hardware
 # * Maps the port for web-access to 8080
@@ -102,6 +98,10 @@ activate = True
 # animate new time with typewriter animation
 typewriter = false
 typewriter_speed = 10
+# Default foreground/background colors
+# BLACK, WHITE, WWHITE, RED, YELLOW, LIME, GREEN, BLUE
+default-fg-color = WWHITE
+default-bg-color = BLACK
 # show time without prefix IT IS/ES IST/etc.
 purist = False
 # define sleep times when the display brightness is turned down [define any 

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -9,6 +9,10 @@ show_startup_message = True
 # Can be a string like "Hello world" or the keyword "ShowIP" to display the wordclocks IP-address (to access the web interface)
 startup_message = ShowIP
 
+# BLACK, WHITE, WWHITE, RED, YELLOW, LIME, GREEN, BLUE
+default-fg-color = WWHITE
+default-bg-color = BLACK
+
 # Set to True to run the software with GTK on a linux system
 # * Does not require any wordclock hardware
 # * Maps the port for web-access to 8080

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -67,6 +67,12 @@ interface = wlan0
 [plugin_matrix]
 activate = True
 
+[plugin_rainbow]
+activate = True
+
+[plugin_time_in_seconds]
+activate = True
+
 [plugin_leds_off]
 activate = True
 

--- a/wordclock_config/wordclock_config.example.cfg
+++ b/wordclock_config/wordclock_config.example.cfg
@@ -102,6 +102,15 @@ typewriter_speed = 10
 # BLACK, WHITE, WWHITE, RED, YELLOW, LIME, GREEN, BLUE
 default-fg-color = WWHITE
 default-bg-color = BLACK
+# Choose the order of the pins for the minutes
+# Like an analogic clock : 1,3,2,0
+#  ___________
+# |           |
+# |  0     1  |
+# |           | 
+# |  2     3  | 
+# |___________| 
+minutes-map = 0,1,2,3
 # show time without prefix IT IS/ES IST/etc.
 purist = False
 # define sleep times when the display brightness is turned down [define any 

--- a/wordclock_plugins/time_default/plugin.py
+++ b/wordclock_plugins/time_default/plugin.py
@@ -84,9 +84,70 @@ class plugin:
         # monitor sleep mode changes to apply brightness
         self.sleep_switch = False
 
-        self.bg_color = wcc.BLACK  # default background color
-        self.word_color = wcc.WWHITE  # default word color
-        self.minute_color = wcc.WWHITE  # default minute color
+        # Choose default fgcolor
+        try:
+            fgcolor = ''.join(config.get('wordclock', 'default-fg-color'))
+        except:
+            # For backward compatibility
+            fgcolor = ''.join(config.get('plugin_time_default', 'default-fg-color'))
+
+        if fgcolor == 'BLACK':
+            self.word_color = wcc.BLACK
+            self.minute_color = wcc.BLACK
+        elif fgcolor == 'WHITE':
+            self.word_color = wcc.WHITE
+            self.minute_color = wcc.WHITE
+        elif fgcolor == 'WWHITE':
+            self.word_color = wcc.WWHITE
+            self.minute_color = wcc.WWHITE
+        elif fgcolor == 'RED':
+            self.word_color = wcc.RED
+            self.minute_color = wcc.RED
+        elif fgcolor == 'YELLOW':
+            self.word_color = wcc.YELLOW
+            self.minute_color = wcc.YELLOW
+        elif fgcolor == 'LIME':
+            self.word_color = wcc.LIME
+            self.minute_color = wcc.LIME
+        elif fgcolor == 'GREEN':
+            self.word_color = wcc.GREEN
+            self.minute_color = wcc.GREEN
+        elif fgcolor == 'BLUE':
+            self.word_color = wcc.BLUE
+            self.minute_color = wcc.BLUE
+        else:
+            print('Could not detect default-fg-color: ' + fgcolor + '.')
+            print('Choosing default: warm white')
+            self.word_color = wcc.WWHITE
+            self.minute_color = wcc.WWHITE
+
+        # Choose default bgcolor
+        try:
+            bgcolor = ''.join(config.get('wordclock', 'default-bg-color'))
+        except:
+            # For backward compatibility
+            bgcolor = ''.join(config.get('plugin_time_default', 'default-bg-color'))
+
+        if bgcolor == 'BLACK':
+            self.bg_color = wcc.BLACK
+        elif bgcolor == 'WHITE':
+            self.bg_color = wcc.WHITE
+        elif bgcolor == 'WWHITE':
+            self.bg_color = wcc.WWHITE
+        elif bgcolor == 'RED':
+            self.bg_color = wcc.RED
+        elif bgcolor == 'YELLOW':
+            self.bg_color = wcc.YELLOW
+        elif bgcolor == 'LIME':
+            self.bg_color = wcc.LIME
+        elif bgcolor == 'GREEN':
+            self.bg_color = wcc.GREEN
+        elif bgcolor == 'BLUE':
+            self.bg_color = wcc.BLUE
+        else:
+            print('Could not detect default-bg-color: ' + bgcolor + '.')
+            print('Choosing default: black')
+            self.bg_color = wcc.BLACK
 
         # Other color modes...
         self.color_modes = \

--- a/wordclock_plugins/time_default/plugin.py
+++ b/wordclock_plugins/time_default/plugin.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 import time_english
+import time_french
 import time_german
 import time_german2
 import time_swabian

--- a/wordclock_plugins/time_default/time_french.py
+++ b/wordclock_plugins/time_default/time_french.py
@@ -1,0 +1,71 @@
+class time_french:
+    """
+    This class returns a given time as a range of LED-indices.
+    Illuminating these LEDs represents the current time on an french WCA
+    """
+
+    def __init__(self):
+        self.prefix = range(0,2) + range(3,6) # -> IL EST
+        self.hours= [range(28,33), \
+            # -> UNE
+            range(7,10), \
+            # -> DEUX
+            range(11,15), \
+            # -> TROIS
+            range(17,22), \
+            # -> QUATRE
+            range(22,28), \
+            # -> CINQ
+            range(33,37), \
+            # -> SIX
+            range(37,40), \
+            # -> SEPT
+            range(40,44), \
+            # -> HUIT
+            range(44,48), \
+            # -> NEUF
+            range(48,52), \
+            # -> DIX
+            range(52,55), \
+            # -> ONZE
+            range(55,59), \
+            # -> DOUZE
+            range(28,33)]
+        self.interfix= [ \
+            # -> HEURE
+            range(60,65), \
+            # -> HEURES
+            range(60,66)]
+        self.minutes=[[], \
+            # -> CINQ
+            range(94,98), \
+            # -> DIX
+            range(74,77), \
+            # -> ET QUART
+            range(77,79) + range(80,85), \
+            # -> VINGT
+            range(88,93), \
+            # -> VINGT-CINQ
+            range(88,98), \
+            # -> ET DEMIE
+            range(99,101) + range(102,107), \
+            # -> MOINS VINGT-CINQ
+            range(66,71) + range(88,98), \
+            # -> MOINS VINGT
+            range(66,71) + range(88,93), \
+            # -> MOINS QUART
+            range(66,71) + range(80,85), \
+            # -> MOINS DIX
+            range(66,71) + range(74,77), \
+            # -> MOINS CINQ
+            range(66,71) + range(94,98)]
+
+    def get_time(self, time, purist):
+        hour=time.hour % 12+(1 if time.minute/5 >= 7 else 0)
+        minute=time.minute/5
+        # Assemble indices
+        return  \
+            (self.prefix if not purist else []) + \
+            self.hours[hour] + \
+            (self.interfix[0] if (hour == 1) else self.interfix[1]) + \
+            self.minutes[minute]

--- a/wordclock_tools/wordclock_colors.py
+++ b/wordclock_tools/wordclock_colors.py
@@ -31,9 +31,10 @@ WHITE = Color(255,255,255)
 WWHITE= Color(255,255, 50)  # Warm white
 YELLOW= Color(255,255,  0)
 ORANGE= Color(212,165,  25)
+LIME  = Color(104,255, 74)
 
 # Summarize colors: [BLACK->WHITE, RED->BLUE (rainbow)]
-colors = [BLACK, WHITE, WWHITE, RED, YELLOW, GREEN, BLUE]
+colors = [BLACK, WHITE, WWHITE, RED, YELLOW, LIME, GREEN, BLUE]
 num_of_colors = len(colors)
 
 

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -9,6 +9,7 @@ from time import sleep
 from threading import Lock
 import wiring
 import wordclock_plugins.time_default.time_english as time_english
+import wordclock_plugins.time_default.time_french as time_french
 import wordclock_plugins.time_default.time_german as time_german
 import wordclock_plugins.time_default.time_german2 as time_german2
 import wordclock_plugins.time_default.time_dutch as time_dutch
@@ -79,6 +80,8 @@ class wordclock_display:
             self.taw = time_dutch.time_dutch()
         elif language == 'english':
             self.taw = time_english.time_english()
+        elif language == 'french':
+            self.taw = time_french.time_french()
         elif language == 'german':
             self.taw = time_german.time_german()
         elif language == 'german2':

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -101,7 +101,7 @@ class wordclock_display:
             bgcolor = ''.join(config.get('plugin_time_default', 'default-bg-color'))
 
         if bgcolor == 'BLACK':
-        self.default_bg_color = wcc.BLACK
+            self.default_bg_color = wcc.BLACK
         elif bgcolor == 'WHITE':
             self.default_bg_color = wcc.WHITE
         elif bgcolor == 'WWHITE':

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -66,11 +66,7 @@ class wordclock_display:
         self.strip.begin()
 
         # Choose default fgcolor
-        try:
-            fgcolor = ''.join(config.get('wordclock', 'default-fg-color'))
-        except:
-            # For backward compatibility
-            fgcolor = ''.join(config.get('plugin_time_default', 'default-fg-color'))
+        fgcolor = ''.join(config.get('plugin_time_default', 'default-fg-color'))
 
         if fgcolor == 'BLACK':
             self.default_fg_color = wcc.BLACK
@@ -94,11 +90,7 @@ class wordclock_display:
             self.default_fg_color = wcc.WWHITE
 
         # Choose default bgcolor
-        try:
-            bgcolor = ''.join(config.get('wordclock', 'default-bg-color'))
-        except:
-            # For backward compatibility
-            bgcolor = ''.join(config.get('plugin_time_default', 'default-bg-color'))
+        bgcolor = ''.join(config.get('plugin_time_default', 'default-bg-color'))
 
         if bgcolor == 'BLACK':
             self.default_bg_color = wcc.BLACK

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -65,6 +65,11 @@ class wordclock_display:
 
         self.strip.begin()
 
+        # Choose default minutes_map
+        minutes_map_str = ''.join(config.get('plugin_time_default', 'minutes-map'))
+        minutes_map_str_list = minutes_map_str.split(',')
+        self.minutes_map = list(map(int, minutes_map_str_list))
+
         # Choose default fgcolor
         fgcolor = ''.join(config.get('plugin_time_default', 'default-fg-color'))
 
@@ -324,7 +329,7 @@ class wordclock_display:
     def setMinutes(self, time, color):
         if time.minute % 5 != 0:
             for i in range(0, time.minute % 5):
-                self.transition_cache_next.minutes[i] = color
+                self.transition_cache_next.minutes[self.minutes_map[i]] = color
 
     def apply_brightness(self, color):
         [h, s, v] = colorsys.rgb_to_hsv(color.r/255.0, color.g/255.0, color.b/255.0)

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -77,7 +77,7 @@ class wordclock_display:
         elif fgcolor == 'WHITE':
             self.default_fg_color = wcc.WHITE
         elif fgcolor == 'WWHITE':
-        self.default_fg_color = wcc.WWHITE
+            self.default_fg_color = wcc.WWHITE
         elif fgcolor == 'RED':
             self.default_fg_color = wcc.RED
         elif fgcolor == 'YELLOW':

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -65,8 +65,61 @@ class wordclock_display:
 
         self.strip.begin()
 
+        # Choose default fgcolor
+        try:
+            fgcolor = ''.join(config.get('wordclock', 'default-fg-color'))
+        except:
+            # For backward compatibility
+            fgcolor = ''.join(config.get('plugin_time_default', 'default-fg-color'))
+
+        if fgcolor == 'BLACK':
+            self.default_fg_color = wcc.BLACK
+        elif fgcolor == 'WHITE':
+            self.default_fg_color = wcc.WHITE
+        elif fgcolor == 'WWHITE':
         self.default_fg_color = wcc.WWHITE
+        elif fgcolor == 'RED':
+            self.default_fg_color = wcc.RED
+        elif fgcolor == 'YELLOW':
+            self.default_fg_color = wcc.YELLOW
+        elif fgcolor == 'LIME':
+            self.default_fg_color = wcc.LIME
+        elif fgcolor == 'GREEN':
+            self.default_fg_color = wcc.GREEN
+        elif fgcolor == 'BLUE':
+            self.default_fg_color = wcc.BLUE
+        else:
+            print('Could not detect default-fg-color: ' + fgcolor + '.')
+            print('Choosing default: warm white')
+            self.default_fg_color = wcc.WWHITE
+
+        # Choose default bgcolor
+        try:
+            bgcolor = ''.join(config.get('wordclock', 'default-bg-color'))
+        except:
+            # For backward compatibility
+            bgcolor = ''.join(config.get('plugin_time_default', 'default-bg-color'))
+
+        if bgcolor == 'BLACK':
         self.default_bg_color = wcc.BLACK
+        elif bgcolor == 'WHITE':
+            self.default_bg_color = wcc.WHITE
+        elif bgcolor == 'WWHITE':
+            self.default_bg_color = wcc.WWHITE
+        elif bgcolor == 'RED':
+            self.default_bg_color = wcc.RED
+        elif bgcolor == 'YELLOW':
+            self.default_bg_color = wcc.YELLOW
+        elif bgcolor == 'LIME':
+            self.default_bg_color = wcc.LIME
+        elif bgcolor == 'GREEN':
+            self.default_bg_color = wcc.GREEN
+        elif bgcolor == 'BLUE':
+            self.default_bg_color = wcc.BLUE
+        else:
+            print('Could not detect default-bg-color: ' + bgcolor + '.')
+            print('Choosing default: black')
+            self.default_bg_color = wcc.BLACK
 
         # Choose language
         try:


### PR DESCRIPTION
* Added the support of french, it follows the layout available in the repo
* You can set the default background and foreground color in the config file
* The color lime has been added
* Added ability to choose the order of the minutes (for example 1,3,2,0 to be like an analogic clock)
* Added the default config for missing plugins